### PR TITLE
Release 3.1.0

### DIFF
--- a/.github/workflows/CI_LINUX.yml
+++ b/.github/workflows/CI_LINUX.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - '*'
       - '!main'
-    tags:        
+    tags:
       - '*'
 
 env:

--- a/.github/workflows/CI_LINUX.yml
+++ b/.github/workflows/CI_LINUX.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - '*'
       - '!main'
+      - '!windows_arm64'
     tags:        
       - '*'
 
@@ -46,7 +47,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build and push Docker image (dev)
+      - name: Build and push Docker image (branch)
         if: github.ref != 'refs/heads/main'
         uses: docker/build-push-action@v3
         with:
@@ -58,7 +59,6 @@ jobs:
           push: true
           tags: |
             ${{ steps.meta.outputs.tags }} 
-            ${{ env.IMAGE_NAME }}:dev
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Build and push Docker image (release)

--- a/.github/workflows/CI_LINUX.yml
+++ b/.github/workflows/CI_LINUX.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - '*'
       - '!main'
-      - '!windows_arm64'
     tags:        
       - '*'
 

--- a/.github/workflows/CI_WINDOWS.yml
+++ b/.github/workflows/CI_WINDOWS.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - '*'
       - '!main'
-    tags:        
+    tags:
       - '*'
 
 env:

--- a/.github/workflows/CI_WINDOWS.yml
+++ b/.github/workflows/CI_WINDOWS.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - '*'
       - '!main'
+      - '!windows_arm64'
     tags:        
       - '*'
 
@@ -51,7 +52,6 @@ jobs:
           push: true
           tags: |
             ${{ steps.meta.outputs.tags }} 
-            ${{ env.IMAGE_NAME }}:dev
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Build and push Docker image (release)
@@ -61,7 +61,6 @@ jobs:
           context: .
           platforms: |
             linux/amd64
-            linux/arm64
           file: ${{ env.DOCKERFILE }}
           push: true
           tags: |

--- a/.github/workflows/CI_WINDOWS.yml
+++ b/.github/workflows/CI_WINDOWS.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - '*'
       - '!main'
-      - '!windows_arm64'
     tags:        
       - '*'
 
@@ -44,7 +43,7 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image (branch)
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/Dockerfile-py3-linux
+++ b/Dockerfile-py3-linux
@@ -1,59 +1,21 @@
-FROM ubuntu:22.04
+FROM python:3.11.2
 SHELL ["/bin/bash", "-i", "-c"]
 
 LABEL maintainer="f.batonogov@yandex.ru"
 
-ARG PYTHON_VERSION=3.11.2
 ARG PYINSTALLER_VERSION=5.8.0
 
 ENV PYPI_URL=https://pypi.python.org/
 ENV PYPI_INDEX_URL=https://pypi.python.org/simple
 
-RUN \
-    set -x \
-    # update system
-    && apt-get update \
-    # install requirements
-    && apt-get install -y --no-install-recommends \
-        build-essential \
-        ca-certificates \
-        curl \
-        wget \
-        git \
-        libbz2-dev \
-        libreadline-dev \
-        libsqlite3-dev \
-        libssl-dev \
-        zlib1g-dev \
-        libffi-dev \
-        # optional libraries
-        libgdbm-dev \
-        libgdbm6 \
-        uuid-dev \
-        # upx
-        upx \
-        # lzma & xz-utils
-        liblzma-dev \
-        xz-utils
-
-# install python
-RUN mkdir python \
-    && cd python \
-    && wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz \
-    && tar xf Python-${PYTHON_VERSION}.tar.xz \
-    && rm Python-${PYTHON_VERSION}.tar.xz \
-    && cd Python-${PYTHON_VERSION} \
-    && ./configure --enable-shared LDFLAGS="-Wl,-rpath /usr/local/lib" \
-    && make \
-    && make install
-
-# install pyinstaller
-RUN pip3 install pyinstaller==$PYINSTALLER_VERSION
-
 COPY entrypoint-linux.sh /entrypoint.sh
 
-RUN mkdir /src/ && \
-    chmod +x /entrypoint.sh
+RUN apt update \
+    && apt install -y --no-install-recommends \
+        upx \
+    && pip3 install pyinstaller==$PYINSTALLER_VERSION \
+    && mkdir /src/ \
+    && chmod +x /entrypoint.sh
 
 VOLUME /src/
 WORKDIR /src/

--- a/Dockerfile-py3-linux
+++ b/Dockerfile-py3-linux
@@ -1,4 +1,4 @@
-FROM python:3.11.2
+FROM python:3.11.3
 SHELL ["/bin/bash", "-i", "-c"]
 
 LABEL maintainer="f.batonogov@yandex.ru"

--- a/Dockerfile-py3-linux
+++ b/Dockerfile-py3-linux
@@ -3,7 +3,7 @@ SHELL ["/bin/bash", "-i", "-c"]
 
 LABEL maintainer="f.batonogov@yandex.ru"
 
-ARG PYTHON_VERSION=3.11.1
+ARG PYTHON_VERSION=3.11.2
 ARG PYINSTALLER_VERSION=5.7.0
 
 ENV PYPI_URL=https://pypi.python.org/

--- a/Dockerfile-py3-linux
+++ b/Dockerfile-py3-linux
@@ -3,7 +3,7 @@ SHELL ["/bin/bash", "-i", "-c"]
 
 LABEL maintainer="f.batonogov@yandex.ru"
 
-ARG PYINSTALLER_VERSION=5.8.0
+ARG PYINSTALLER_VERSION=5.9.0
 
 ENV PYPI_URL=https://pypi.python.org/
 ENV PYPI_INDEX_URL=https://pypi.python.org/simple

--- a/Dockerfile-py3-linux
+++ b/Dockerfile-py3-linux
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-i", "-c"]
 LABEL maintainer="f.batonogov@yandex.ru"
 
 ARG PYTHON_VERSION=3.11.2
-ARG PYINSTALLER_VERSION=5.7.0
+ARG PYINSTALLER_VERSION=5.8.0
 
 ENV PYPI_URL=https://pypi.python.org/
 ENV PYPI_INDEX_URL=https://pypi.python.org/simple

--- a/Dockerfile-py3-linux
+++ b/Dockerfile-py3-linux
@@ -37,15 +37,15 @@ RUN \
         xz-utils
 
 # install python
-RUN mkdir python && \
-    cd python && \
-    wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz && \
-    tar xf Python-${PYTHON_VERSION}.tar.xz && \
-    rm Python-${PYTHON_VERSION}.tar.xz && \
-    cd Python-${PYTHON_VERSION} && \
-    ./configure --enable-shared LDFLAGS="-Wl,-rpath /usr/local/lib" && \
-    make && \
-    make install
+RUN mkdir python \
+    && cd python \
+    && wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz \
+    && tar xf Python-${PYTHON_VERSION}.tar.xz \
+    && rm Python-${PYTHON_VERSION}.tar.xz \
+    && cd Python-${PYTHON_VERSION} \
+    && ./configure --enable-shared LDFLAGS="-Wl,-rpath /usr/local/lib" \
+    && make \
+    && make install
 
 # install pyinstaller
 RUN pip3 install pyinstaller==$PYINSTALLER_VERSION

--- a/Dockerfile-py3-windows
+++ b/Dockerfile-py3-windows
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="f.batonogov@yandex.ru"
 

--- a/Dockerfile-py3-windows
+++ b/Dockerfile-py3-windows
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ARG WINE_VERSION=winehq-stable
 ARG PYTHON_VERSION=3.11.2
-ARG PYINSTALLER_VERSION=5.7.0
+ARG PYINSTALLER_VERSION=5.8.0
 
 # we need wine for this all to work, so we'll use the PPA
 RUN set -x \

--- a/Dockerfile-py3-windows
+++ b/Dockerfile-py3-windows
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ARG WINE_VERSION=winehq-stable
 ARG PYTHON_VERSION=3.11.2
-ARG PYINSTALLER_VERSION=5.8.0
+ARG PYINSTALLER_VERSION=5.9.0
 
 # we need wine for this all to work, so we'll use the PPA
 RUN set -x \

--- a/Dockerfile-py3-windows
+++ b/Dockerfile-py3-windows
@@ -5,7 +5,7 @@ LABEL maintainer="f.batonogov@yandex.ru"
 ENV DEBIAN_FRONTEND noninteractive
 
 ARG WINE_VERSION=winehq-stable
-ARG PYTHON_VERSION=3.11.2
+ARG PYTHON_VERSION=3.11.3
 ARG PYINSTALLER_VERSION=5.9.0
 
 # we need wine for this all to work, so we'll use the PPA

--- a/Dockerfile-py3-windows
+++ b/Dockerfile-py3-windows
@@ -5,7 +5,7 @@ LABEL maintainer="f.batonogov@yandex.ru"
 ENV DEBIAN_FRONTEND noninteractive
 
 ARG WINE_VERSION=winehq-stable
-ARG PYTHON_VERSION=3.11.1
+ARG PYTHON_VERSION=3.11.2
 ARG PYINSTALLER_VERSION=5.7.0
 
 # we need wine for this all to work, so we'll use the PPA

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2016 Chris R
+Copyright (c) 2021 Fedor Batonogov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,14 +4,13 @@
 
 Current PyInstaller version used:
 
-- 5.7.0 for Python 3.11.1
+- 5.7.0 for **Python 3.11.1**
 
 ## Tags
 
-`batonogov/pyinstaller-linux` both have few tags `:latest`, `:dev`.
-`batonogov/pyinstaller-windows` both have few tags `:latest`, `:dev`.
+`batonogov/pyinstaller-linux` or `batonogov/pyinstaller-windows` both have few tags `:latest`, `:dev`, `:3.0.1`.
 
-The `:latest` tag runs Python 3.11.1 x86-64.
+The `:latest` tag runs Python 3.11.1.
 
 ## Usage
 
@@ -37,7 +36,7 @@ docker run -v "$(pwd):/src/" batonogov/pyinstaller-linux
 
 will build your PyInstaller project into `dist/`. The binary will have the same name as your `.spec` file.
 
-##### How do I install system libraries or dependencies that my Python packages need?
+### How do I install system libraries or dependencies that my Python packages need?
 
 You'll need to supply a custom command to Docker to install system pacakges. Something like:
 
@@ -47,17 +46,17 @@ docker run -v "$(pwd):/src/" --entrypoint /bin/sh batonogov/pyinstaller-linux -c
 
 Replace `wget` with the dependencies / package(s) you need to install.
 
-##### How do I generate a .spec file?
+### How do I generate a .spec file?
 
 `docker run -v "$(pwd):/src/" batonogov/pyinstaller-linux "pyinstaller --onefile your-script.py"`
 
 will generate a `spec` file for `your-script.py` in your current working directory. See the PyInstaller docs for more information.
 
-##### How do I change the PyInstaller version used?
+### How do I change the PyInstaller version used?
 
 Add `pyinstaller=5.5.0` to your `requirements.txt`.
 
-##### Is it possible to use a package mirror?
+### Is it possible to use a package mirror?
 
 Yes, by supplying the `PYPI_URL` and `PYPI_INDEX_URL` environment variables that point to your PyPi mirror.
 
@@ -69,7 +68,7 @@ None
 
 ### 2023
 
-#### [3.0.1] - upcoming
+#### [3.0.1] - 24.01.2023
 
 - New GitHub CI
 - Added arm64 architecture in linux images

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | `:latest` or `:3.0.2` | 3.11.2         | 5.8.0               |
 | `:3.0.1`              | 3.11.1         | 5.7.0               |
 | `:python-3.10`        | 3.10.10        | 5.7.0               |
-| `:dev`                | See dev branch | See dev branch      |
+| `:dev`                | 3.11.2         | 5.9.0               |
 
 ## Usage
 
@@ -69,9 +69,10 @@ None
 
 ### 2023
 
-### [3.1.0] - Upcoming
+### [3.0.3] - Upcoming
 
-- Update Dockerfile for Linux Image
+- Updated Dockerfile for Linux Image
+- Updated Pyintaller 5.8.0 -> 5.9.0
 
 #### [3.0.2] - 13.02.2023
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 `batonogov/pyinstaller-linux` or `batonogov/pyinstaller-windows` both have few tags:
 
-| TAG                   | Python version | Pyinstaller version |
-| --------------------- | -------------- | ------------------- |
-| `:latest` or `:3.0.2` | 3.11.2         | 5.8.0               |
-| `:3.0.1`              | 3.11.1         | 5.7.0               |
-| `:python-3.10`        | 3.10.10        | 5.7.0               |
+| TAG                | Python version | Pyinstaller version |
+| ------------------ | -------------- | ------------------- |
+| `:latest`/`:3.0.2` | 3.11.2         | 5.8.0               |
+| `:3.0.1`           | 3.11.1         | 5.7.0               |
+| `:python-3.10`     | 3.10.10        | 5.7.0               |
 
 ## Usage
 
@@ -62,7 +62,7 @@ Yes, by supplying the `PYPI_URL` and `PYPI_INDEX_URL` environment variables that
 
 ## Known Issues
 
-None
+[Outdated Microsoft C++ Build Tools](https://github.com/batonogov/docker-pyinstaller/issues/11)
 
 ## History
 
@@ -72,6 +72,7 @@ None
 
 - Linux container now uses Python base image
 - Updated Pyintaller 5.8.0 -> 5.9.0
+- Updated Python 3.11.2 -> 3.11.3
 
 #### [3.0.2] - 13.02.2023
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,10 @@ Current PyInstaller version used:
 
 `batonogov/pyinstaller-linux` or `batonogov/pyinstaller-windows` both have few tags:
 
-| TAG                   | Python version |
-| --------------------- | -------------- |
-| `:latest` or `:3.0.1` | 3.11.1         |
-| `:dev`                | 3.11.2         |
-| `:python-3.10`        | 3.10.9         |
-| `:python-3.9`         | 3.9.16         |
-| `:python-3.8`         | 3.8.16         |
-| `:python-3.7`         | 3.7.16         |
+| TAG                   | Python version | Pyinstaller version |
+| --------------------- | -------------- | ------------------- |
+| `:latest` or `:3.0.1` | 3.11.1         | 5.7.0               |
+| `:python-3.10`        | 3.10.9         | 5.7.0               |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Current PyInstaller version used:
 | TAG                   | Python version | Pyinstaller version |
 | --------------------- | -------------- | ------------------- |
 | `:latest` or `:3.0.1` | 3.11.1         | 5.7.0               |
-| `:python-3.10`        | 3.10.9         | 5.7.0               |
+| `:python-3.10`        | 3.10.10        | 5.7.0               |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 | `:latest` or `:3.0.2` | 3.11.2         | 5.8.0               |
 | `:3.0.1`              | 3.11.1         | 5.7.0               |
 | `:python-3.10`        | 3.10.10        | 5.7.0               |
-| `:dev`                | 3.11.2         | 5.9.0               |
 
 ## Usage
 
@@ -69,9 +68,9 @@ None
 
 ### 2023
 
-### [3.0.3] - Upcoming
+### [3.1.0] - Upcoming
 
-- Updated Dockerfile for Linux Image
+- Linux container now uses Python base image
 - Updated Pyintaller 5.8.0 -> 5.9.0
 
 #### [3.0.2] - 13.02.2023

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 **batonogov/pyinstaller-linux** and **batonogov/pyinstaller-windows** are a pair of Docker containers to ease compiling Python applications to binaries / exe files.
 
-Current PyInstaller version used:
-
-- 5.7.0 for **Python 3.11.2**
-
 ## Tags
 
 `batonogov/pyinstaller-linux` or `batonogov/pyinstaller-windows` both have few tags:
@@ -14,6 +10,7 @@ Current PyInstaller version used:
 | --------------------- | -------------- | ------------------- |
 | `:latest` or `:3.0.1` | 3.11.1         | 5.7.0               |
 | `:python-3.10`        | 3.10.10        | 5.7.0               |
+| `:dev`                | See dev branch | See dev branch      |
 
 ## Usage
 
@@ -44,7 +41,7 @@ will build your PyInstaller project into `dist/`. The binary will have the same 
 You'll need to supply a custom command to Docker to install system pacakges. Something like:
 
 ```console
-docker run -v "$(pwd):/src/" --entrypoint /bin/sh batonogov/pyinstaller-linux -c "apt-get update -y && apt-get install -y wget && /entrypoint.sh"
+docker run -v "$(pwd):/src/" --entrypoint /bin/sh batonogov/pyinstaller-linux -c "apt update -y && apt install -y wget && /entrypoint.sh"
 ```
 
 Replace `wget` with the dependencies / package(s) you need to install.
@@ -57,7 +54,7 @@ will generate a `spec` file for `your-script.py` in your current working directo
 
 ### How do I change the PyInstaller version used?
 
-Add `pyinstaller=5.5.0` to your `requirements.txt`.
+Add `pyinstaller=5.7.0` to your `requirements.txt`.
 
 ### Is it possible to use a package mirror?
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 | TAG                   | Python version | Pyinstaller version |
 | --------------------- | -------------- | ------------------- |
-| `:latest` or `:3.0.1` | 3.11.1         | 5.7.0               |
+| `:latest` or `:3.0.2` | 3.11.2         | 5.8.0               |
+| `:3.0.1`              | 3.11.1         | 5.7.0               |
 | `:python-3.10`        | 3.10.10        | 5.7.0               |
 | `:dev`                | See dev branch | See dev branch      |
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ will generate a `spec` file for `your-script.py` in your current working directo
 
 ### How do I change the PyInstaller version used?
 
-Add `pyinstaller=5.7.0` to your `requirements.txt`.
+Add `pyinstaller==5.7.0` to your `requirements.txt`.
 
 ### Is it possible to use a package mirror?
 
@@ -68,6 +68,10 @@ None
 ## History
 
 ### 2023
+
+### [3.1.0] - Upcoming
+
+- Update Dockerfile for Linux Image
 
 #### [3.0.2] - 13.02.2023
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ Current PyInstaller version used:
 
 ## Tags
 
-`batonogov/pyinstaller-linux` or `batonogov/pyinstaller-windows` both have few tags `:latest`, `:dev`, `:3.0.1`.
+`batonogov/pyinstaller-linux` or `batonogov/pyinstaller-windows` both have few tags:
 
-The `:latest` tag runs Python 3.11.1.
+| TAG                   | Python version |
+| --------------------- | -------------- |
+| `:latest` or `:3.0.1` | 3.11.1         |
+| `:python-3.10`        | 3.10.9         |
+| `:python-3.9`         | 3.9.16         |
+| `:python-3.8`         | 3.8.16         |
+| `:python-3.7`         | 3.7.16         |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Current PyInstaller version used:
 
-- 5.7.0 for **Python 3.11.1**
+- 5.7.0 for **Python 3.11.2**
 
 ## Tags
 
@@ -13,6 +13,7 @@ Current PyInstaller version used:
 | TAG                   | Python version |
 | --------------------- | -------------- |
 | `:latest` or `:3.0.1` | 3.11.1         |
+| `:dev`                | 3.11.2         |
 | `:python-3.10`        | 3.10.9         |
 | `:python-3.9`         | 3.9.16         |
 | `:python-3.8`         | 3.8.16         |
@@ -73,6 +74,10 @@ None
 ## History
 
 ### 2023
+
+#### [3.0.2] - upcoming
+
+- Updated Python 3.11.1 -> 3.11.2
 
 #### [3.0.1] - 24.01.2023
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 | TAG                | Python version | Pyinstaller version |
 | ------------------ | -------------- | ------------------- |
-| `:latest`/`:3.0.2` | 3.11.2         | 5.8.0               |
+| `:latest`/`:3.1.0` | 3.11.3         | 5.9.0               |
+| `:3.0.2`           | 3.11.2         | 5.8.0               |
 | `:3.0.1`           | 3.11.1         | 5.7.0               |
 | `:python-3.10`     | 3.10.10        | 5.7.0               |
 
@@ -54,7 +55,7 @@ will generate a `spec` file for `your-script.py` in your current working directo
 
 ### How do I change the PyInstaller version used?
 
-Add `pyinstaller==5.7.0` to your `requirements.txt`.
+Add `pyinstaller==5.8.0` to your `requirements.txt`.
 
 ### Is it possible to use a package mirror?
 
@@ -68,7 +69,9 @@ Yes, by supplying the `PYPI_URL` and `PYPI_INDEX_URL` environment variables that
 
 ### 2023
 
-### [3.1.0] - Upcoming
+Now release information will be [here](https://github.com/batonogov/docker-pyinstaller/releases).
+
+### [3.1.0] - 08.03.2023
 
 - Linux container now uses Python base image
 - Updated Pyintaller 5.8.0 -> 5.9.0

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ None
 
 ### 2023
 
-#### [3.0.2] - upcoming
+#### [3.0.2] - 13.02.2023
 
 - Updated Python 3.11.1 -> 3.11.2
 - Updated Ubuntu 20.04 -> 22.04 for windows

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ None
 
 - Updated Python 3.11.1 -> 3.11.2
 - Updated Ubuntu 20.04 -> 22.04 for windows
+- Updated Pyintaller 5.7.0 -> 5.8.0
 
 #### [3.0.1] - 24.01.2023
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 `batonogov/pyinstaller-linux` or `batonogov/pyinstaller-windows` both have few tags:
 
-| TAG                | Python version | Pyinstaller version |
-| ------------------ | -------------- | ------------------- |
-| `:latest`/`:3.1.0` | 3.11.3         | 5.9.0               |
-| `:3.0.2`           | 3.11.2         | 5.8.0               |
-| `:3.0.1`           | 3.11.1         | 5.7.0               |
-| `:python-3.10`     | 3.10.10        | 5.7.0               |
+| TAG                    | Python version | Pyinstaller version |
+| ---------------------- | -------------- | ------------------- |
+| `:latest`/`:3.1.0`     | 3.11.3         | 5.9.0               |
+| `:python-3.11`/`:3.0.2`| 3.11.2         | 5.8.0               |
+| `:3.0.1`               | 3.11.1         | 5.7.0               |
+| `:python-3.10`         | 3.10.10        | 5.7.0               |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ None
 #### [3.0.2] - upcoming
 
 - Updated Python 3.11.1 -> 3.11.2
+- Updated Ubuntu 20.04 -> 22.04 for windows
 
 #### [3.0.1] - 24.01.2023
 

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -4,6 +4,6 @@ if [ -z $1 ];
 then
     echo "Enter dockerfile name"
 else
-    docker build -f $1 -t test_image . && \
-    docker run -v "$(pwd)/test:/src/" test_image "pyinstaller main.py --onefile"
+    docker build -f $1 -t pyinstaller_test . && \
+    docker run -v "$(pwd)/test:/src/" pyinstaller_test "pyinstaller main.py --onefile"
 fi

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.28.1
+requests==2.28.2


### PR DESCRIPTION
### [3.1.0] - 08.03.2023

- Linux container now uses Python base image
- Updated Pyintaller 5.8.0 -> 5.9.0
- Updated Python 3.11.2 -> 3.11.3