### PR TITLE
Multiple specfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ docker run -v "$(pwd):/src/" batonogov/pyinstaller-linux
 ```
 
 will build your PyInstaller project into `dist/`. The binary will have the same name as your `.spec` file.
+### How do I specify the spec file from which the executable should be build?
+
+You'll need to pass an environment variable called `SPECFILE` with the path (relative or absoulte) to your spec file, like so:
+
+```console
+docker run -v "$(pwd):/src/" -e SPECFILE=./main-nogui.spec batonogov/pyinstaller-linux 
+```
+
+This will build the executable from the spec file `main-nogui.spec`.
 
 ### How do I install system libraries or dependencies that my Python packages need?
 

--- a/entrypoint-linux.sh
+++ b/entrypoint-linux.sh
@@ -13,7 +13,12 @@ set -e
 # Useful for CI pipiles which use docker for their build steps
 # and don't allow that much flexibility to mount volumes
 WORKDIR=${SRCDIR:-/src}
-
+# Allow the user to specify the spec file
+# Sometimes there are 2 executables to be built from one
+# folder, this allows the user to specify which one
+# should we build.
+# In case it's not defind, find the first match for `*.spec`
+SPECFILE=${SPECFILE:-$(find . -maxdepth 1 -type f -name '*.spec' -print -quit)}
 # In case the user specified a custom URL for PYPI, then use
 # that one, instead of the default one.
 
@@ -40,7 +45,7 @@ fi # [ -f requirements.txt ]
 echo "$@"
 
 if [[ "$@" == "" ]]; then
-    pyinstaller --clean -y --dist ./dist --workpath /tmp *.spec
+    pyinstaller --clean -y --dist ./dist --workpath /tmp $SPECFILE
     chown -R --reference=. ./dist
 else
     sh -c "$@"

--- a/entrypoint-windows.sh
+++ b/entrypoint-windows.sh
@@ -10,7 +10,12 @@ set -e
 # Useful for CI pipiles which use docker for their build steps
 # and don't allow that much flexibility to mount volumes
 WORKDIR=${SRCDIR:-/src}
-
+# Allow the user to specify the spec file
+# Sometimes there are 2 executables to be built from one
+# folder, this allows the user to specify which one
+# should we build.
+# In case it's not defind, find the first match for `*.spec`
+SPECFILE=${SPECFILE:-$(find . -maxdepth 1 -type f -name '*.spec' -print -quit)}
 #
 # In case the user specified a custom URL for PYPI, then use
 # that one, instead of the default one.
@@ -38,7 +43,7 @@ fi # [ -f requirements.txt ]
 echo "$@"
 
 if [[ "$@" == "" ]]; then
-    pyinstaller --clean -y --dist ./dist --workpath /tmp *.spec
+    pyinstaller --clean -y --dist ./dist --workpath /tmp $SPECFILE
     chown -R --reference=. ./dist
 else
     sh -c "$@"


### PR DESCRIPTION
When you have 2 or more specfiles in the source code, one of them is not going to be built. Allow user to specify the specfile via enviorement variable SPECFILE. 

Sorry for the mess, everything is now good!