### PR TITLE
Docker image for MacOSX

### DIFF
--- a/Dockerfile-py3-osx
+++ b/Dockerfile-py3-osx
@@ -1,0 +1,23 @@
+FROM sickcodes/docker-osx:latest
+SHELL ["/bin/bash", "-i", "-c"]
+
+LABEL maintainer="f.batonogov@yandex.ru"
+
+ARG PYINSTALLER_VERSION=6.3.0
+
+ENV PYPI_URL=https://pypi.python.org/
+ENV PYPI_INDEX_URL=https://pypi.python.org/simple
+
+COPY entrypoint-osx.sh /entrypoint.sh
+
+USER root
+
+RUN pacman --noconfirm -Sy python-pipx
+
+RUN pipx ensurepath && pipx install pyinstaller==$PYINSTALLER_VERSION \
+    && chmod +x /entrypoint.sh
+
+VOLUME /src/
+WORKDIR /src/
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint-osx.sh
+++ b/entrypoint-osx.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -i
+
+# Add path
+# echo 'export PATH=$PATH:$HOME/.pyenv/versions/$(ls $HOME/.pyenv/versions/)/bin/' >> ~/.bashrc
+
+# Fail on errors.
+set -e
+
+# Make sure .bashrc is sourced
+. /root/.bashrc
+
+# Allow the workdir to be set using an env var.
+# Useful for CI pipiles which use docker for their build steps
+# and don't allow that much flexibility to mount volumes
+WORKDIR=${SRCDIR:-/src}
+# Allow the user to specify the spec file
+# Sometimes there are 2 executables to be built from one
+# folder, this allows the user to specify which one
+# should we build.
+# In case it's not defind, find the first match for `*.spec`
+SPECFILE=${SPECFILE:-$(find . -maxdepth 1 -type f -name '*.spec' -print -quit)}
+# In case the user specified a custom URL for PYPI, then use
+# that one, instead of the default one.
+
+if [[ "$PYPI_URL" != "https://pypi.python.org/" ]] || \
+   [[ "$PYPI_INDEX_URL" != "https://pypi.python.org/simple" ]]; then
+    # the funky looking regexp just extracts the hostname, excluding port
+    # to be used as a trusted-host.
+    mkdir -p /root/.pip
+    echo "[global]" > /root/.pip/pip.conf
+    echo "index = $PYPI_URL" >> /root/.pip/pip.conf
+    echo "index-url = $PYPI_INDEX_URL" >> /root/.pip/pip.conf
+    echo "trusted-host = $(echo $PYPI_URL | perl -pe 's|^.*?://(.*?)(:.*?)?/.*$|$1|')" >> /root/.pip/pip.conf
+
+    echo "Using custom pip.conf: "
+    cat /root/.pip/pip.conf
+fi
+
+cd $WORKDIR
+
+if [ -f requirements.txt ]; then
+    pipx install -r requirements.txt
+fi # [ -f requirements.txt ]
+
+echo "$@"
+
+if [[ "$@" == "" ]]; then
+    pyinstaller --clean -y --dist ./dist --workpath /tmp $SPECFILE
+    chown -R --reference=. ./dist
+else
+    sh -c "$@"
+fi # [[ "$@" == "" ]]


### PR DESCRIPTION
Adding an image for building MacOSX binaries.

This steps on a preexisting base image that is somewhat too huge (and appears to support GUI), but is subject to future optimisations.

Also, the final pyinstaller binary is not tested due to lack of access to a native OSX environment. Any actual confirmation would be greatly appreciated.