### PR TITLE
Update VC++ Redistributable to latest VS 2015-2022

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3.1.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: 🎉 Thank you for your first issue! We will look into it soon.
-          pr-message: 🚀 Thank you for your first pull request! It helps improve our project.
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: 🎉 Thank you for your first issue! We will look into it soon.
+          pr_message: 🚀 Thank you for your first pull request! It helps improve our project.

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -9,7 +9,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/first-interaction@v3.1.0
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: 🎉 Thank you for your first issue! We will look into it soon.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build Windows image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: Dockerfile-py3-windows
@@ -47,13 +47,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build Linux image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: Dockerfile-py3-linux
@@ -80,13 +80,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build Linux slim image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: Dockerfile-py3-linux-slim

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '*'
       - '!main'
+  pull_request:
+    branches:
+      - main
 
 jobs:
   windows:
@@ -12,45 +15,96 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6.0.2
-      - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Windows image
+        uses: docker/build-push-action@v6
         with:
-          version: 3.x
-      - name: Run Tests
-        run: task test:windows
+          context: .
+          file: Dockerfile-py3-windows
+          tags: pyinstaller-test-windows:latest
+          load: true
+          cache-from: type=gha,scope=windows
+          cache-to: type=gha,mode=max,scope=windows
+
+      - name: Build binary with PyInstaller
+        run: >
+          docker run --rm
+          -v "$(pwd)/test:/src/"
+          pyinstaller-test-windows:latest
+          "pyinstaller main.py --onefile"
+
+      - name: Verify Windows binary with Wine
+        run: >
+          docker run --rm
+          -v "$(pwd)/test:/src/"
+          pyinstaller-test-windows:latest
+          "wine C:/src/dist/main.exe"
 
   linux:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6.0.2
-      - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Linux image
+        uses: docker/build-push-action@v6
         with:
-          version: 3.x
-      - name: Run Tests
-        run: task test:linux
+          context: .
+          file: Dockerfile-py3-linux
+          tags: pyinstaller-test-linux:latest
+          load: true
+          cache-from: type=gha,scope=linux
+          cache-to: type=gha,mode=max,scope=linux
+
+      - name: Build binary with PyInstaller
+        run: >
+          docker run --rm
+          -v "$(pwd)/test:/src/"
+          pyinstaller-test-linux:latest
+          "pyinstaller main.py --onefile"
+
+      - name: Verify Linux binary
+        run: >
+          docker run --rm
+          -v "$(pwd)/test:/src/"
+          pyinstaller-test-linux:latest
+          ./dist/main
 
   linux-slim:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6.0.2
-      - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
-        with:
-          version: 3.x
-      - name: Run Tests
-        run: task test:linux-slim
 
-  # osx:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout Repo
-  #       uses: actions/checkout@v6.0.2
-  #     - name: Install Task
-  #       uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
-  #       with:
-  #         version: 3.x
-  #     - name: Run Tests
-  #       run: task test:osx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Linux slim image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile-py3-linux-slim
+          tags: pyinstaller-test-linux-slim:latest
+          load: true
+          cache-from: type=gha,scope=linux-slim
+          cache-to: type=gha,mode=max,scope=linux-slim
+
+      - name: Build binary with PyInstaller
+        run: >
+          docker run --rm
+          -v "$(pwd)/test:/src/"
+          pyinstaller-test-linux-slim:latest
+          "pyinstaller main.py --onefile"
+
+      - name: Verify Linux slim binary
+        run: >
+          docker run --rm
+          -v "$(pwd)/test:/src/"
+          pyinstaller-test-linux-slim:latest
+          ./dist/main

--- a/Dockerfile-py3-windows
+++ b/Dockerfile-py3-windows
@@ -70,15 +70,18 @@ RUN set -x \
 ENV W_DRIVE_C=/wine/drive_c
 ENV W_WINDIR_UNIX="$W_DRIVE_C/windows"
 ENV W_SYSTEM64_DLLS="$W_WINDIR_UNIX/system32"
-ENV W_TMP="$W_DRIVE_C/windows/temp/_$0"
+ENV W_TMP="$W_DRIVE_C/windows/temp/_vcredist"
 
 # install Microsoft Visual C++ Redistributable for Visual Studio 2015-2022 dll files
 RUN set -x \
     && rm -rf "$W_TMP" && mkdir -p "$W_TMP" \
     && wget -P "$W_TMP" https://aka.ms/vs/17/release/vc_redist.x64.exe \
     && cabextract -q --directory="$W_TMP" "$W_TMP"/vc_redist.x64.exe \
+    # extract nested cab archives from the redistributable
     && for f in "$W_TMP"/*; do cabextract -q --directory="$W_TMP" "$f" 2>/dev/null || true; done \
+    # second pass: extract DLLs from the inner cab files
     && for f in "$W_TMP"/*; do cabextract -q --directory="$W_TMP" "$f" 2>/dev/null || true; done \
+    && find "$W_TMP" -name '*.dll' | grep -q . || { echo "ERROR: no DLLs extracted from VC++ Redist"; exit 1; } \
     && find "$W_TMP" -name '*.dll' -exec sh -c 'rename "s/_/-/g" "$@"' _ {} + \
     && find "$W_TMP" -name '*.dll' -exec cp {} "$W_SYSTEM64_DLLS"/ \;
 

--- a/Dockerfile-py3-windows
+++ b/Dockerfile-py3-windows
@@ -72,10 +72,10 @@ ENV W_WINDIR_UNIX="$W_DRIVE_C/windows"
 ENV W_SYSTEM64_DLLS="$W_WINDIR_UNIX/system32"
 ENV W_TMP="$W_DRIVE_C/windows/temp/_$0"
 
-# install Microsoft Visual C++ Redistributable for Visual Studio 2017 dll files
+# install Microsoft Visual C++ Redistributable for Visual Studio 2015-2022 dll files
 RUN set -x \
     && rm -f "$W_TMP"/* \
-    && wget -P "$W_TMP" https://download.visualstudio.microsoft.com/download/pr/11100230/15ccb3f02745c7b206ad10373cbca89b/VC_redist.x64.exe \
+    && wget -P "$W_TMP" https://aka.ms/vs/17/release/vc_redist.x64.exe \
     && cabextract -q --directory="$W_TMP" "$W_TMP"/VC_redist.x64.exe \
     && cabextract -q --directory="$W_TMP" "$W_TMP/a10" \
     && cabextract -q --directory="$W_TMP" "$W_TMP/a11" \

--- a/Dockerfile-py3-windows
+++ b/Dockerfile-py3-windows
@@ -74,14 +74,13 @@ ENV W_TMP="$W_DRIVE_C/windows/temp/_$0"
 
 # install Microsoft Visual C++ Redistributable for Visual Studio 2015-2022 dll files
 RUN set -x \
-    && rm -f "$W_TMP"/* \
+    && rm -rf "$W_TMP" && mkdir -p "$W_TMP" \
     && wget -P "$W_TMP" https://aka.ms/vs/17/release/vc_redist.x64.exe \
     && cabextract -q --directory="$W_TMP" "$W_TMP"/vc_redist.x64.exe \
-    && find "$W_TMP" -maxdepth 1 -type f ! -name '*.exe' ! -name '*.dll' -exec sh -c \
-        'cabextract -q --directory="$1" "$2" 2>/dev/null || true' _ "$W_TMP" {} \; \
-    && cd "$W_TMP" \
-    && rename 's/_/\-/g' *.dll \
-    && cp "$W_TMP"/*.dll "$W_SYSTEM64_DLLS"/
+    && for f in "$W_TMP"/*; do cabextract -q --directory="$W_TMP" "$f" 2>/dev/null || true; done \
+    && for f in "$W_TMP"/*; do cabextract -q --directory="$W_TMP" "$f" 2>/dev/null || true; done \
+    && find "$W_TMP" -name '*.dll' -exec sh -c 'rename "s/_/-/g" "$@"' _ {} + \
+    && find "$W_TMP" -name '*.dll' -exec cp {} "$W_SYSTEM64_DLLS"/ \;
 
 # install pyinstaller
 RUN /usr/bin/pip install --no-cache-dir pyinstaller==$PYINSTALLER_VERSION

--- a/Dockerfile-py3-windows
+++ b/Dockerfile-py3-windows
@@ -76,7 +76,7 @@ ENV W_TMP="$W_DRIVE_C/windows/temp/_$0"
 RUN set -x \
     && rm -f "$W_TMP"/* \
     && wget -P "$W_TMP" https://aka.ms/vs/17/release/vc_redist.x64.exe \
-    && cabextract -q --directory="$W_TMP" "$W_TMP"/VC_redist.x64.exe \
+    && cabextract -q --directory="$W_TMP" "$W_TMP"/vc_redist.x64.exe \
     && cabextract -q --directory="$W_TMP" "$W_TMP/a10" \
     && cabextract -q --directory="$W_TMP" "$W_TMP/a11" \
     && cd "$W_TMP" \

--- a/Dockerfile-py3-windows
+++ b/Dockerfile-py3-windows
@@ -77,8 +77,8 @@ RUN set -x \
     && rm -f "$W_TMP"/* \
     && wget -P "$W_TMP" https://aka.ms/vs/17/release/vc_redist.x64.exe \
     && cabextract -q --directory="$W_TMP" "$W_TMP"/vc_redist.x64.exe \
-    && cabextract -q --directory="$W_TMP" "$W_TMP/a10" \
-    && cabextract -q --directory="$W_TMP" "$W_TMP/a11" \
+    && find "$W_TMP" -maxdepth 1 -type f ! -name '*.exe' ! -name '*.dll' -exec sh -c \
+        'cabextract -q --directory="$1" "$2" 2>/dev/null || true' _ "$W_TMP" {} \; \
     && cd "$W_TMP" \
     && rename 's/_/\-/g' *.dll \
     && cp "$W_TMP"/*.dll "$W_SYSTEM64_DLLS"/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,6 +25,7 @@ tasks:
     cmds:
       - task: build:windows
       - docker run --rm -v "$(pwd)/{{.TEST_DIR}}:/src/" {{.IMAGE_PREFIX}}-windows "pyinstaller main.py --onefile"
+      - docker run --rm -v "$(pwd)/{{.TEST_DIR}}:/src/" {{.IMAGE_PREFIX}}-windows "wine C:/src/dist/main.exe"
 
   test:linux:
     desc: Build and test Linux image

--- a/test/main.py
+++ b/test/main.py
@@ -41,16 +41,16 @@ def check_flask():
 def check_psutil():
     cpu = psutil.cpu_count()
     mem = psutil.virtual_memory()
-    assert cpu is not None and cpu > 0, f"Unexpected cpu_count: {cpu}"
+    assert cpu > 0, f"Unexpected cpu_count: {cpu}"
     assert mem.total > 0, f"Unexpected virtual_memory total: {mem.total}"
     print(f"psutil OK: {cpu} CPUs, {mem.total // (1024**2)} MB RAM")
 
 
 def check_requests():
     session = requests.Session()
-    assert session is not None
+    assert isinstance(session, requests.Session)
     adapter = session.get_adapter("https://")
-    assert adapter is not None
+    assert isinstance(adapter, requests.adapters.HTTPAdapter)
     print("requests OK: Session created")
 
 

--- a/test/main.py
+++ b/test/main.py
@@ -3,6 +3,8 @@ import sys
 
 import numpy as np
 import pandas as pd
+import psutil
+import requests
 from flask import Flask, jsonify
 from flask_wtf.csrf import CSRFProtect
 from sqlalchemy import create_engine, text
@@ -36,6 +38,22 @@ def check_flask():
     print("Flask OK")
 
 
+def check_psutil():
+    cpu = psutil.cpu_count()
+    mem = psutil.virtual_memory()
+    assert cpu is not None and cpu > 0, f"Unexpected cpu_count: {cpu}"
+    assert mem.total > 0, f"Unexpected virtual_memory total: {mem.total}"
+    print(f"psutil OK: {cpu} CPUs, {mem.total // (1024**2)} MB RAM")
+
+
+def check_requests():
+    session = requests.Session()
+    assert session is not None
+    adapter = session.get_adapter("https://")
+    assert adapter is not None
+    print("requests OK: Session created")
+
+
 def check_sqlalchemy():
     engine = create_engine("sqlite:///:memory:")
     with engine.connect() as connection:
@@ -50,6 +68,8 @@ def main():
     check_platform()
     check_numpy_pandas()
     check_flask()
+    check_psutil()
+    check_requests()
     check_sqlalchemy()
     print("All checks passed")
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,5 +2,6 @@ flask==3.1.3
 Flask-WTF==1.2.2
 numpy==2.1.2
 pandas==2.2.3
+psutil==7.0.0
 requests==2.32.4
 sqlalchemy==2.0.36


### PR DESCRIPTION
## Summary
- Update VC++ Redistributable to latest VS 2015-2022 via `aka.ms` permalink
- Fix DLL extraction for newer VC++ Redist versions (recursive cabextract)
- Fix undefined `$0` variable in `W_TMP` env
- Rework test workflow: Docker Buildx with GHA cache, `pull_request` trigger, binary verification
- Add `psutil` and `requests` to test suite (C-extension coverage for #11)
- Windows binary verification via Wine in CI and Taskfile
- Pin all GitHub Actions to full commit SHA
- Fix `greetings.yml` input names for `first-interaction` v3.1.0

Closes #11

## Test plan
- [x] Build the Windows Docker image and verify VC++ Redist DLLs are correctly extracted
- [x] Run a test PyInstaller build with a package that depends on VC++ runtime (`psutil`)
- [x] Verify Windows binary runs via Wine
- [x] Linux and Linux-slim builds pass with binary verification
- [x] All CI workflows green